### PR TITLE
Secure option overrides window.location.protocol

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -228,7 +228,7 @@
       }
     }
 
-    var prefix = window.location.protocol == 'file:' ? "file://" : (secure ? 'https://' : 'http://');
+    var prefix = secure ? 'https://' : window.location.protocol + '//';
     if (cloud_name.match(/^\//) && !secure) {    
       prefix = "/res" + cloud_name;
     } else {


### PR DESCRIPTION
When the secure option is truthy, the the URL prefix will be set to https:// regardless of what the window.location.protocol is. When the option is falsy, the URL prefix will be the same as the window.location.protocol.

This request pertains to Issue #17, if you're interested in the changes, that would be great!

Thanks
