### PR TITLE
Updating the webp image to ensure the webpify function handles Android 4.1.2

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -367,7 +367,7 @@
       var webp_canary = new Image();
       webp_canary.onerror = webp.reject;
       webp_canary.onload = webp.resolve;
-      webp_canary.src = 'data:image/webp;base64,UklGRjIAAABXRUJQVlA4ICYAAACyAgCdASoBAAEALmk0mk0iIiIiIgBoSygABc6zbAAA/v56QAAAAA==';
+      webp_canary.src = 'data:image/webp;base64,UklGRi4AAABXRUJQVlA4TCEAAAAvAUAAEB8wAiMwAgSSNtse/cXjxyCCmrYNWPwmHRH9jwMA';
     }
     $(function() {
       webp.done(function() {


### PR DESCRIPTION
I noticed some of the images (.png) where not displayed correctly on my android device 4.1.2.
Changing the image:data, allowed me to get the proper image loading on my 3 Android test devices.
I assume it is due to the following "(Lossless, Transparency, Android 4.2.1+)" http://developer.android.com/guide/appendix/media-formats.html
