### PR TITLE
fix non-fileupload code

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -19,7 +19,9 @@
     var $ = window.jQuery;
     factory($);
     $(function() {
-      $("input.cloudinary-fileupload[type=file]").cloudinary_fileupload();
+      if($.fn.cloudinary_fileupload !== undefined) {
+        $("input.cloudinary-fileupload[type=file]").cloudinary_fileupload();
+      }
     });
   }
 }(function ($) {


### PR DESCRIPTION
## Scenario

Just add the `jquery.cloudinary.js (v1.0.14.0)` file to your code, without adding any of those file upload files
## Problem

``` haskell
Uncaught TypeError: undefined is not a function jquery.cloudinary.js:23
(anonymous function) jquery.cloudinary.js:23
```
## Solution

Do not try to create fileupload inputs if there is no fileupload code
