### PR TITLE
Fix dpr cache to store by key indexed by

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -499,8 +499,8 @@
       var dpr_string = device_pixel_ratio_cache[dpr];      
       if (!dpr_string) {
         // Find closest supported DPR (to work correctly with device zoom)
-        dpr = closest_above($.cloudinary.supported_dpr_values, dpr);
-        dpr_string = dpr.toString();
+        dpr_used = closest_above($.cloudinary.supported_dpr_values, dpr);
+        dpr_string = dpr_used.toString();
         if (dpr_string.match(/^\d+$/)) dpr_string += ".0";
         device_pixel_ratio_cache[dpr] = dpr_string;
       }


### PR DESCRIPTION
We would try to lookup values in the dpr cache by the value we were
getting from the client but then store the result based on the key of
the discretized DPR.
