### PR TITLE
Traverse ancestors in DOM to find clientWidth for responsive images

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -30,7 +30,7 @@
   var OLD_AKAMAI_SHARED_CDN = "cloudinary-a.akamaihd.net";
   var AKAMAI_SHARED_CDN = "res.cloudinary.com";
   var SHARED_CDN = AKAMAI_SHARED_CDN;
-  
+
   function utf8_encode (argString) {
     // http://kevin.vanzonneveld.net
     // +   original by: Webtoolkit.info (http://www.webtoolkit.info/)
@@ -82,7 +82,7 @@
 
     return utftext;
   }
-  
+
   function crc32 (str) {
     // http://kevin.vanzonneveld.net
     // +   original by: Webtoolkit.info (http://www.webtoolkit.info/)
@@ -122,7 +122,7 @@
       return [];
     } else if ($.isArray(arg)) {
       return arg;
-    } else { 
+    } else {
       return [arg];
     }
   }
@@ -141,7 +141,7 @@
       return [];
     }
     delete options.transformation;
-    var base_transformations = []; 
+    var base_transformations = [];
     for (var i = 0; i < transformations.length; i++) {
       var transformation = transformations[i];
       if (typeof(transformation) == 'string') {
@@ -159,12 +159,12 @@
       var split_size = size.split("x");
       options.width = split_size[0];
       options.height = split_size[1];
-    }    
+    }
   }
 
   function process_html_dimensions(options) {
     var width = options.width, height = options.height;
-    var has_layer = options.overlay || options.underlay;     
+    var has_layer = options.overlay || options.underlay;
     var crop = options.crop;
     var use_as_html_dimensions = !has_layer && !options.angle && crop != "fit" && crop != "limit" && crop != "lfill";
     if (use_as_html_dimensions) {
@@ -174,7 +174,7 @@
     if (!crop && !has_layer) {
       delete options.width;
       delete options.height;
-    }    
+    }
   }
 
   var TRANSFORMATION_PARAM_NAME_MAPPING = {
@@ -210,12 +210,12 @@
     angle: function(angle){ return build_array(angle).join("."); },
     background: function(background) { return background.replace(/^#/, 'rgb:');},
     border: function(border) {
-      if ($.isPlainObject(border)) { 
+      if ($.isPlainObject(border)) {
         var border_width = "" + (border.width || 2);
         var border_color = (border.color || "black").replace(/^#/, 'rgb:');
         border = border_width + "px_solid_" + border_color;
       }
-      return border;        
+      return border;
     },
     color: function(color) { return color.replace(/^#/, 'rgb:');},
     dpr: function(dpr) {
@@ -237,12 +237,12 @@
     var base_transformations = process_base_transformations(options);
     process_size(options);
     process_html_dimensions(options);
-    
+
     var params = [];
     for (var param in TRANSFORMATION_PARAM_NAME_MAPPING) {
       var value = option_consume(options, param);
       if (!present(value)) continue;
-      if (TRANSFORMATION_PARAM_VALUE_MAPPING[param]) {        
+      if (TRANSFORMATION_PARAM_VALUE_MAPPING[param]) {
         value = TRANSFORMATION_PARAM_VALUE_MAPPING[param](value);
       }
       if (!present(value)) continue;
@@ -264,13 +264,13 @@
         prefix += document.location.pathname;
       } else if (url[0] != '/') {
         prefix += document.location.pathname.replace(/\/[^\/]*$/, '/');
-      }        
+      }
       url = prefix + url;
     }
     return url;
   }
 
-  function cloudinary_url(public_id, options) { 
+  function cloudinary_url(public_id, options) {
     options = options || {};
     var type = option_consume(options, 'type', 'upload');
     if (type == 'fetch') {
@@ -282,25 +282,25 @@
     var format = option_consume(options, 'format');
     var cloud_name = option_consume(options, 'cloud_name', $.cloudinary.config().cloud_name);
     if (!cloud_name) throw "Unknown cloud_name";
-    var private_cdn = option_consume(options, 'private_cdn', $.cloudinary.config().private_cdn);    
-    var secure_distribution = option_consume(options, 'secure_distribution', $.cloudinary.config().secure_distribution);    
+    var private_cdn = option_consume(options, 'private_cdn', $.cloudinary.config().private_cdn);
+    var secure_distribution = option_consume(options, 'secure_distribution', $.cloudinary.config().secure_distribution);
     var cname = option_consume(options, 'cname', $.cloudinary.config().cname);
     var cdn_subdomain = option_consume(options, 'cdn_subdomain', $.cloudinary.config().cdn_subdomain);
     var shorten = option_consume(options, 'shorten', $.cloudinary.config().shorten);
     var secure = option_consume(options, 'secure', window.location.protocol == 'https:');
     var protocol = option_consume(options, 'protocol', $.cloudinary.config().protocol);
-    var trust_public_id = option_consume(options, 'trust_public_id'); 
+    var trust_public_id = option_consume(options, 'trust_public_id');
 
     if (type == 'fetch') {
-      public_id = absolutize(public_id); 
+      public_id = absolutize(public_id);
     }
-    
+
     if (public_id.match(/^https?:/)) {
       if (type == "upload" || type == "asset") return public_id;
-      public_id = encodeURIComponent(public_id).replace(/%3A/g, ":").replace(/%2F/g, "/"); 
+      public_id = encodeURIComponent(public_id).replace(/%3A/g, ":").replace(/%2F/g, "/");
     } else {
       // Make sure public_id is URI encoded.
-      public_id = encodeURIComponent(decodeURIComponent(public_id)).replace(/%3A/g, ":").replace(/%2F/g, "/");      
+      public_id = encodeURIComponent(decodeURIComponent(public_id)).replace(/%3A/g, ":").replace(/%2F/g, "/");
       if (format) {
         if (!trust_public_id) public_id = public_id.replace(/\.(jpg|png|gif|webp)$/, '');
         public_id = public_id + "." + format;
@@ -313,7 +313,7 @@
       prefix = "/res" + cloud_name;
     } else {
       var shared_domain = !private_cdn;
-      if (secure) {        
+      if (secure) {
         if (!secure_distribution || secure_distribution == OLD_AKAMAI_SHARED_CDN) {
           secure_distribution = private_cdn ? cloud_name + "-res.cloudinary.com" : SHARED_CDN;
         }
@@ -351,7 +351,7 @@
     var width = option_consume(options, 'html_width');
     var height = option_consume(options, 'html_height');
     if (width) options.width = width;
-    if (height) options.height = height;    
+    if (height) options.height = height;
     return url;
   }
 
@@ -375,10 +375,10 @@
   var device_pixel_ratio_cache = {};
 
   $.cloudinary = {
-    CF_SHARED_CDN: CF_SHARED_CDN,  
+    CF_SHARED_CDN: CF_SHARED_CDN,
     OLD_AKAMAI_SHARED_CDN: OLD_AKAMAI_SHARED_CDN,
     AKAMAI_SHARED_CDN: AKAMAI_SHARED_CDN,
-    SHARED_CDN: SHARED_CDN,    
+    SHARED_CDN: SHARED_CDN,
     config: function(new_config, new_value) {
       if (!cloudinary_config) {
         cloudinary_config = {};
@@ -397,8 +397,8 @@
     },
     url: function(public_id, options) {
       options = $.extend({}, options);
-      return cloudinary_url(public_id, options);    
-    },    
+      return cloudinary_url(public_id, options);
+    },
     url_internal: cloudinary_url,
     transformation_string: function(options) {
       options = $.extend({}, options);
@@ -430,7 +430,7 @@
       if (!public_id.match(/.css$/)) options.format = 'css';
       return $.cloudinary.url(public_id, options);
     },
-    /** 
+    /**
      * Turn on hidpi (dpr_auto) and responsive (w_auto) processing according to the current container size and the device pixel ratio.
      * Use the following classes:
      * - cld-hidpi - only set dpr_auto
@@ -438,7 +438,7 @@
      * @param: options
      * - responsive_resize - should responsive images be updated on resize (default: true).
      * - responsive_debounce - if set, how many milliseconds after resize is done before the image is replaces (default: 100). Set to 0 to disable.
-     * - responsive_use_stoppoints: 
+     * - responsive_use_stoppoints:
      *   - true - always use stoppoints for width
      *   - "resize" - use exact width on first render and stoppoints on resize (default)
      *   - false - always use exact width
@@ -456,12 +456,12 @@
           var debounce = get_config('responsive_debounce', responsive_config, 100);
           function reset() {
             if (timeout) {
-              clearTimeout(timeout); 
+              clearTimeout(timeout);
               timeout = null;
             }
           }
           function run() {
-            $('img.cld-responsive').cloudinary_update(responsive_config);  
+            $('img.cld-responsive').cloudinary_update(responsive_config);
           }
           function wait() {
             reset();
@@ -494,9 +494,9 @@
       }
       return closest_above(stoppoints, width);
     },
-    device_pixel_ratio: function() {    
+    device_pixel_ratio: function() {
       var dpr = window.devicePixelRatio || 1;
-      var dpr_string = device_pixel_ratio_cache[dpr];      
+      var dpr_string = device_pixel_ratio_cache[dpr];
       if (!dpr_string) {
         // Find closest supported DPR (to work correctly with device zoom)
         var dpr_used = closest_above($.cloudinary.supported_dpr_values, dpr);
@@ -513,24 +513,24 @@
     this.filter('img').each(function() {
       var img_options = $.extend({width: $(this).attr('width'), height: $(this).attr('height'),
                                   src: $(this).attr('src')}, $(this).data(), options);
-      var public_id = option_consume(img_options, 'source', option_consume(img_options, 'src')); 
+      var public_id = option_consume(img_options, 'source', option_consume(img_options, 'src'));
       var url = prepare_html_url(public_id, img_options);
       $(this).data('src-cache', url).attr({width: img_options.width, height: img_options.height});
     }).cloudinary_update(options);
     return this;
   };
 
-  /** 
+  /**
    * Update hidpi (dpr_auto) and responsive (w_auto) fields according to the current container size and the device pixel ratio.
    * Only images marked with the cld-responsive class have w_auto updated.
-   * options: 
-   * - responsive_use_stoppoints: 
+   * options:
+   * - responsive_use_stoppoints:
    *   - true - always use stoppoints for width
    *   - "resize" - use exact width on first render and stoppoints on resize (default)
    *   - false - always use exact width
    * - responsive:
    *   - true - enable responsive on this element. Can be done by adding cld-responsive.
-   *            Note that $.cloudinary.responsive() should be called once on the page. 
+   *            Note that $.cloudinary.responsive() should be called once on the page.
    */
   $.fn.cloudinary_update = function(options) {
     options = options || {};
@@ -547,15 +547,26 @@
       if (!src) return;
       var responsive = $(this).hasClass('cld-responsive') && src.match(/\bw_auto\b/);
       if (responsive) {
-        var container = $(this).parent()[0];
-        var containerWidth = container ? container.clientWidth : 0;
+        var parents = $(this).parents(),
+            parentsLength = parents.length,
+            container,
+            containerWidth = 0,
+            nthParent;
+
+        for (nthParent = 0; nthParent < parentsLength; nthParent+=1) {
+          container = parents[nthParent];
+          if (container && container.clientWidth) {
+            containerWidth = container.clientWidth;
+            break;
+          }
+        }
         if (containerWidth == 0) {
           // container doesn't know the size yet. Usually because the image is hidden or outside the DOM.
-          return; 
+          return;
         }
-        
-        var requestedWidth = exact ? containerWidth : $.cloudinary.calc_stoppoint(this, containerWidth);          
-        var currentWidth = $(this).data('width') || 0; 
+
+        var requestedWidth = exact ? containerWidth : $.cloudinary.calc_stoppoint(this, containerWidth);
+        var currentWidth = $(this).data('width') || 0;
         if (requestedWidth > currentWidth) {
           // requested width is larger, fetch new image
           $(this).data('width', requestedWidth);
@@ -580,7 +591,7 @@
     var that = this;
     options = options || {};
     webp_options = webp_options || options;
-    if (!webp) { 
+    if (!webp) {
       webp = $.Deferred();
       var webp_canary = new Image();
       webp_canary.onerror = webp.reject;
@@ -629,23 +640,23 @@
       }, options);
     }
     this.fileupload(options);
-    
+
     if (initializing) {
       this.bind("fileuploaddone", function(e, data) {
-        if (data.result.error) return;      
-        data.result.path = ["v", data.result.version, "/", data.result.public_id, 
+        if (data.result.error) return;
+        data.result.path = ["v", data.result.version, "/", data.result.public_id,
                             data.result.format ? "." + data.result.format : ""].join("");
-    
+
         if (data.cloudinaryField && data.form.length > 0) {
-          var upload_info = [data.result.resource_type, data.result.type, data.result.path].join("/") + "#" + data.result.signature;  
+          var upload_info = [data.result.resource_type, data.result.type, data.result.path].join("/") + "#" + data.result.signature;
           var multiple = $(e.target).prop("multiple");
           var add_field = function() {
             $('<input></input>').attr({type: "hidden", name: data.cloudinaryField}).val(upload_info).appendTo(data.form);
           };
-          
+
           if (multiple) {
             add_field();
-          } else {          
+          } else {
             var field = $(data.form).find('input[name="' + data.cloudinaryField + '"]');
             if (field.length > 0) {
               field.val(upload_info);
@@ -656,7 +667,7 @@
         }
         $(e.target).trigger('cloudinarydone', data);
       });
-      
+
       this.bind("fileuploadstart", function(e){
         $(e.target).trigger('cloudinarystart');
       });
@@ -684,13 +695,13 @@
     }
     return this;
   };
-  
+
   $.fn.cloudinary_upload_url = function(remote_url) {
-    this.fileupload('option', 'formData').file = remote_url; 
-    this.fileupload('add', { files: [ remote_url ] }); 
-    delete(this.fileupload('option', 'formData').file);    
+    this.fileupload('option', 'formData').file = remote_url;
+    this.fileupload('add', { files: [ remote_url ] });
+    delete(this.fileupload('option', 'formData').file);
   };
-    
+
   $.fn.unsigned_cloudinary_upload = function(upload_preset, upload_params, options) {
     options = options || {};
     upload_params = $.extend({}, upload_params) || {};
@@ -704,12 +715,12 @@
     for (var key in upload_params) {
       var value = upload_params[key];
       if ($.isPlainObject(value)) {
-        upload_params[key] = $.map(value, function(v, k){return k + "=" + v;}).join("|");      
+        upload_params[key] = $.map(value, function(v, k){return k + "=" + v;}).join("|");
       } else if ($.isArray(value)) {
         if (value.length > 0 && $.isArray(value[0])) {
-          upload_params[key] = $.map(value, function(array_value){return array_value.join(",");}).join("|");                
+          upload_params[key] = $.map(value, function(array_value){return array_value.join(",");}).join("|");
         } else {
-          upload_params[key] = value.join(",");  
+          upload_params[key] = value.join(",");
         }
       }
     }
@@ -724,14 +735,14 @@
       options.cloudinaryField = options.cloudinary_field;
       delete options.cloudinary_field;
     }
-        
+
     var html_options = options.html || {};
     html_options["class"] = "cloudinary_fileupload " + (html_options["class"] || "");
     if (options.multiple) html_options.multiple = true;
     this.attr(html_options).cloudinary_fileupload(options);
     return this;
   };
-  
+
   $.cloudinary.unsigned_upload_tag = function(upload_preset, upload_params, options) {
     return $('<input/>').attr({type: "file", name: "file"}).unsigned_cloudinary_upload(upload_preset, upload_params, options);
   };

--- a/test/spec/CloudinarySpec.js
+++ b/test/spec/CloudinarySpec.js
@@ -1,12 +1,19 @@
 describe("cloudinary", function() {
-  var result;
+  var result,
+      fixtureContainer;
   beforeEach(function() {
     $.cloudinary.config({
       cloud_name: "test123"
     });
+    fixtureContainer = $('<div id="fixture">');
+    fixtureContainer.appendTo('body');
   });
-  
-  it("should use cloud_name from config", function() {    
+
+  afterEach(function() {
+    fixtureContainer.remove();
+  });
+
+  it("should use cloud_name from config", function() {
     result = $.cloudinary.url_internal("test");
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/test") ;
   });
@@ -38,53 +45,53 @@ describe("cloudinary", function() {
     expect(options).toEqual({});
     expect(result).toEqual("https://something.cloudfront.net/image/upload/test") ;
   });
-  
+
   it("should use protocol based on secure if given", function(){
     if (window.location.protocol === "http:") {
       options = {secure: true};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("https://res.cloudinary.com/test123/image/upload/test") ;
-    
+
       options = {secure: false};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("http://res.cloudinary.com/test123/image/upload/test") ;
-    
+
       options = {};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("http://res.cloudinary.com/test123/image/upload/test") ;
     }
-    
+
     if (window.location.protocol === "https:") {
       options = {secure: true};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("https://res.cloudinary.com/test123/image/upload/test") ;
-      
+
       options = {secure: false};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("http://res.cloudinary.com/test123/image/upload/test") ;
-      
+
       options = {};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("https://res.cloudinary.com/test123/image/upload/test") ;
     }
-    
+
     if (window.location.protocol === "file:") {
       options = {secure: true};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("https://res.cloudinary.com/test123/image/upload/test") ;
-      
+
       options = {secure: false};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
       expect(result).toEqual("file://res.cloudinary.com/test123/image/upload/test") ;
-      
+
       options = {};
       result = $.cloudinary.url_internal("test", options);
       expect(options).toEqual({});
@@ -98,8 +105,8 @@ describe("cloudinary", function() {
     expect(options).toEqual({});
     expect(result).toEqual(window.location.protocol+"//test123-res.cloudinary.com/image/upload/test") ;
   });
-  
-  it("should use format from options", function() {    
+
+  it("should use format from options", function() {
     options = {"format": "jpg"};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({});
@@ -138,50 +145,50 @@ describe("cloudinary", function() {
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/a_auto,c_scale,h_100,w_100/test") ;
     expect(options).toEqual({});
   });
-  
-  it("should use x, y, radius, prefix, gravity and quality from options", function() {    
+
+  it("should use x, y, radius, prefix, gravity and quality from options", function() {
     options = {"x": 1, "y": 2, "radius": 3, "gravity": "center", "quality": 0.4, "prefix": "a"};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({});
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/g_center,p_a,q_0.4,r_3,x_1,y_2/test") ;
   });
-  
-  it("should support named tranformation", function() {    
+
+  it("should support named tranformation", function() {
     options = {"transformation": "blip"};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({});
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/t_blip/test") ;
   });
 
-  it("should support array of named tranformations", function() {    
+  it("should support array of named tranformations", function() {
     options = {"transformation": ["blip", "blop"]};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({});
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/t_blip.blop/test") ;
   });
 
-  it("should support base tranformation", function() {    
+  it("should support base tranformation", function() {
     options = {"transformation": {"x": 100, "y": 100, "crop": "fill"}, "crop": "crop", "width": 100};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({"html_width": 100});
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_fill,x_100,y_100/c_crop,w_100/test") ;
   });
 
-  it("should support array of base tranformations", function() {    
+  it("should support array of base tranformations", function() {
     options = {"transformation": [{"x": 100, "y": 100, "width": 200, "crop": "fill"}, {"radius": 10}], "crop": "crop", "width": 100};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({"html_width": 100});
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_fill,w_200,x_100,y_100/r_10/c_crop,w_100/test") ;
   });
 
-  it("should not include empty tranformations", function() {    
+  it("should not include empty tranformations", function() {
     options = {"transformation": [{}, {"x": 100, "y": 100, "crop": "fill"}, {}]};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({});
     expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_fill,x_100,y_100/test") ;
   });
 
-  it("should support size", function() {    
+  it("should support size", function() {
     options = {"size": "10x10", "crop": "crop"};
     result = $.cloudinary.url_internal("test", options);
     expect(options).toEqual({"html_width": "10", "html_height": "10"});
@@ -221,94 +228,94 @@ describe("cloudinary", function() {
     options = {"type": "fetch"}
     result = $.cloudinary.url_internal("http://blah.com/hello?a=b", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/fetch/http://blah.com/hello%3Fa%3Db") 
-  }); 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/fetch/http://blah.com/hello%3Fa%3Db")
+  });
 
   it("should escape http urls", function() {
     options = {"type": "youtube"};
     result = $.cloudinary.url_internal("http://www.youtube.com/watch?v=d9NF2edxy-M", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/youtube/http://www.youtube.com/watch%3Fv%3Dd9NF2edxy-M") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/youtube/http://www.youtube.com/watch%3Fv%3Dd9NF2edxy-M")
   });
-  
+
   it("should support background", function() {
     options = {"background": "red"}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/b_red/test") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/b_red/test")
     options = {"background": "#112233"}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/b_rgb:112233/test") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/b_rgb:112233/test")
   });
-  
+
   it("should support default_image", function() {
     options = {"default_image": "default"}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/d_default/test") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/d_default/test")
   });
-  
+
   it("should support angle", function() {
     options = {"angle": 12}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/a_12/test") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/a_12/test")
   });
-  
+
   it("should support format for fetch urls", function() {
     options = {"format": "jpg", "type": "fetch"}
     result = $.cloudinary.url_internal("http://cloudinary.com/images/logo.png", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/fetch/f_jpg/http://cloudinary.com/images/logo.png") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/fetch/f_jpg/http://cloudinary.com/images/logo.png")
   });
 
   it("should support extenal cname", function() {
     options = {"cname": "hello.com"}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//hello.com/test123/image/upload/test") 
+    expect(result).toEqual(window.location.protocol+"//hello.com/test123/image/upload/test")
   });
 
   it("should support extenal cname with cdn_subdomain on", function() {
     options = {"cname": "hello.com", "cdn_subdomain": true}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//a2.hello.com/test123/image/upload/test") 
+    expect(result).toEqual(window.location.protocol+"//a2.hello.com/test123/image/upload/test")
   });
 
   it("should support effect", function() {
     options = {"effect": "sepia"}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/e_sepia/test") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/e_sepia/test")
   });
-  
+
   it("should support effect with param", function() {
     options = {"effect": ["sepia", 10]}
     result = $.cloudinary.url_internal("test", options)
     expect(options).toEqual({});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/e_sepia:10/test") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/e_sepia:10/test")
   });
-  
+
   it("should support fetch_image", function() {
     result = $.cloudinary.fetch_image("http://example.com/hello.jpg?a=b").attr("src");
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/fetch/http://example.com/hello.jpg%3Fa%3Db") 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/fetch/http://example.com/hello.jpg%3Fa%3Db")
   });
-  
+
   layers = {overlay: "l", underlay: "u"};
   for (var layer in layers) {
     it("should support " + layer, function() {
       options = {}; options[layer] = "text:hello";
       result = $.cloudinary.url_internal("test", options)
       expect(options).toEqual({});
-      expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/" + layers[layer] + "_text:hello/test") 
+      expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/" + layers[layer] + "_text:hello/test")
     });
     it("should not pass width/height to html for " + layer, function() {
       options = {height: 100, width: 100}; options[layer] = "text:hello";
       result = $.cloudinary.url_internal("test", options)
       expect(options).toEqual({});
-      expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/h_100," + layers[layer] + "_text:hello,w_100/test") 
+      expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/h_100," + layers[layer] + "_text:hello,w_100/test")
     });
   }
 
@@ -386,26 +393,26 @@ describe("cloudinary", function() {
 
   it("should add version if public_id contains /", function() {
     result = $.cloudinary.url_internal("folder/test");
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/v1/folder/test"); 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/v1/folder/test");
     result = $.cloudinary.url_internal("folder/test", {version: 123});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/v123/folder/test"); 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/v123/folder/test");
   });
 
   it("should not add version if public_id contains version already", function() {
     result = $.cloudinary.url_internal("v1234/test");
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/v1234/test"); 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/v1234/test");
   });
 
   it("should allow to shorted image/upload urls", function() {
     result = $.cloudinary.url_internal("test", {shorten: true});
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/iu/test"); 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/iu/test");
   });
-  
+
   it("should generate sprite css urls", function() {
     result = $.cloudinary.sprite_css("test");
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/sprite/test.css"); 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/sprite/test.css");
     result = $.cloudinary.sprite_css("test.css");
-    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/sprite/test.css"); 
+    expect(result).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/sprite/test.css");
   });
 
   it("should escape public_ids", function() {
@@ -416,7 +423,7 @@ describe("cloudinary", function() {
         "a-b": "a-b",
         "a??b": "a%3F%3Fb"};
     for (var source in tests) {
-      var target = tests[source]; 
+      var target = tests[source];
       var result = $.cloudinary.url(source);
       expect(result).toEqual(window.location.protocol + "//res.cloudinary.com/test123/image/upload/" + target);
     }
@@ -428,7 +435,7 @@ describe("cloudinary", function() {
     expect(options).toEqual({});
     expect(result).toEqual("custom://res.cloudinary.com/test123/image/upload/test") ;
   });
-  
+
   it("should create an unsigned upload tag", function(){
     $.cloudinary.config().cloud_name = 'test';
     var result = $.cloudinary.unsigned_upload_tag("test", {context: {alt: "alternative", caption: "cap"}, tags: ['a','b']}, {width: 100, cloud_name: "test1", multiple: true});
@@ -467,24 +474,34 @@ describe("cloudinary", function() {
   it("should correctly resize responsive images", function() {
     var container, img;
     var dpr = $.cloudinary.device_pixel_ratio();
-    container = $('<div></div>').css({width: 101}).appendTo('body');
+    container = $('<div></div>').css({width: 101}).appendTo(fixtureContainer);
     runs(function() {
       img = $.cloudinary.image("sample.jpg", {width: "auto", dpr: "auto", crop: "scale", responsive: true}).appendTo(container);
       expect(img.attr('src')).toEqual(null);
       $.cloudinary.responsive();
-      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_101/sample.jpg"); 
+      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_101/sample.jpg");
       container.css('width', 111);
-      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_101/sample.jpg"); 
+      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_101/sample.jpg");
       $(window).resize();
     });
     waits(200);
     runs(function() {
-      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_120/sample.jpg"); 
+      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_120/sample.jpg");
       container.css('width', 101);
     });
     waits(200);
     runs(function() {
-      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_120/sample.jpg"); 
+      expect(img.attr('src')).toEqual(window.location.protocol+"//res.cloudinary.com/test123/image/upload/c_scale,dpr_"+dpr+",w_120/sample.jpg");
     });
+  });
+
+  it("should traverse up the DOM to find a parent that has clientWidth", function() {
+    var aContainer, divContainer, img;
+    divContainer = $('<div>').css({width: 101}).appendTo(fixtureContainer);
+    aContainer = $('<a>').appendTo(divContainer);
+    img = $.cloudinary.image("sample.jpg", {width: "auto", dpr: "auto", crop: "scale", responsive: true}).appendTo(aContainer);
+
+    $.cloudinary.responsive();
+    expect(img.attr('src')).not.toEqual(undefined);
   });
 });


### PR DESCRIPTION
We have an `<img>` tag whose parent is an `<a>` tag. In the `cloudinary_update` function, it attempts to retrieve the `clientWidth` based on the immediate parent (see [here](https://github.com/cloudinary/cloudinary_js/blob/master/js/jquery.cloudinary.js#L552-L555)). Since our immediate parent is an `<a>` tag, this results in 0 which exits out early. We added logic to traverse up the DOM to grab the ancestor's `clientWidth`.

Note: the other parts of the diff are trailing whitespace fixes.
