### PR TITLE
Fix XSS vulnerability on cloudinary_cors.html

### DIFF
--- a/html/cloudinary_cors.html
+++ b/html/cloudinary_cors.html
@@ -34,7 +34,13 @@ var JSON;if(!JSON){JSON={}}(function(){function str(a,b){var c,d,e,f,g=gap,h,i=b
       }
       return JSON.stringify(result);
     }
-    document.body.innerHTML=parse(window.location.search.slice(1));
+
+    // IE below version 9 doesn't have textContent, so we have to use innerText
+    if (document.body.hasOwnProperty('textContent')) {
+      document.body.textContent = parse(window.location.search.slice(1));
+    } else {
+      document.body.innerText = parse(window.location.search.slice(1));
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
We use Cloudinary and recently had an XSS vulnerability in it pointed out to us by a security researcher.  The cloudinary_cors.html file runs unvalidated input based on a URL parameter, and must be hosted on our domain. Which means a malicious actor could send a user to the specially crafted URL and steal cookies etc from our website.

To fix this, it should set its content via textContent instead of HTML. This PR should fix that (and hopefully not disrupt its legitimate usage).
