### PR TITLE
Do not auto init for Meteor package.

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -19,7 +19,7 @@
     var $ = window.jQuery;
     factory($);
     $(function() {
-      if($.fn.cloudinary_fileupload !== undefined) {
+      if($.fn.cloudinary_fileupload !== undefined && typeof Package === 'undefined') {
         $("input.cloudinary-fileupload[type=file]").cloudinary_fileupload();
       }
     });


### PR DESCRIPTION
Added check to prevent auto-init for Meteor because the DOM element may not be rendered yet when cloudinary is loaded.