### PR TITLE
Fix layer cloning

### DIFF
--- a/src/layer/layer.js
+++ b/src/layer/layer.js
@@ -82,6 +82,10 @@ class Layer {
     return compact(components).join(":");
   }
 
+  clone() {
+    return new this.constructor(this.options);
+  }
+
 }
 
 export default Layer;

--- a/src/parameters.js
+++ b/src/parameters.js
@@ -296,25 +296,33 @@ class LayerParam extends Param {
   // @return [string] layer transformation string
   // @private
   value() {
-    let result;
-    let layerOptions = this.origValue;
-    if (isPlainObject(layerOptions)) {
-      layerOptions = withCamelCaseKeys(layerOptions);
-      if (layerOptions.resourceType === "text" || (layerOptions.text != null)) {
-        result = new TextLayer(layerOptions).toString();
-      } else if (layerOptions.resourceType === "subtitles") {
-        result = new SubtitlesLayer(layerOptions).toString();
-      } else if (layerOptions.resourceType === "fetch" || (layerOptions.url != null)) {
-        result = new FetchLayer(layerOptions).toString();
-      } else {
-        result = new Layer(layerOptions).toString();
-      }
-    } else if (isString(layerOptions) && /^fetch:.+/.test(layerOptions)) {
-      result = new FetchLayer(layerOptions.substr(6)).toString();
-    } else {
-      result = layerOptions;
+    if (this.origValue == null) {
+      return '';
     }
-    return result;
+    let result;
+    if (this.origValue instanceof Layer) {
+      result = this.origValue;
+    } else if (isPlainObject(this.origValue)) {
+      let layerOptions = withCamelCaseKeys(this.origValue);
+      if (layerOptions.resourceType === "text" || (layerOptions.text != null)) {
+        result = new TextLayer(layerOptions);
+      } else if (layerOptions.resourceType === "subtitles") {
+        result = new SubtitlesLayer(layerOptions);
+      } else if (layerOptions.resourceType === "fetch" || (layerOptions.url != null)) {
+        result = new FetchLayer(layerOptions);
+      } else {
+        result = new Layer(layerOptions);
+      }
+    } else if (isString(this.origValue)) {
+      if (/^fetch:.+/.test(this.origValue)) {
+        result = new FetchLayer(this.origValue.substr(6));
+      } else {
+        result = this.origValue;
+      }
+    } else {
+      result = '';
+    }
+    return result.toString();
   }
 
   textStyle(layer) {

--- a/src/transformation.js
+++ b/src/transformation.js
@@ -272,28 +272,28 @@ class TransformationBase {
    * @returns {Transformation} Returns this instance for chaining
    */
   fromOptions(options) {
-    if (!isEmpty(options)) {
-      if (options instanceof TransformationBase) {
-        this.fromTransformation(options);
-      } else {
-        options || (options = {});
-        if (isString(options) || isArray(options)) {
-          options = {
-            transformation: options
-          };
+    if (options instanceof TransformationBase) {
+      this.fromTransformation(options);
+    } else {
+      options || (options = {});
+      if (isString(options) || isArray(options)) {
+        options = {
+          transformation: options
+        };
+      }
+      options = cloneDeep(options, function (value) {
+        if (value instanceof TransformationBase || value instanceof Layer) {
+          return new value.clone();
         }
-        options = cloneDeep(options, function (value) {
-          if (value instanceof TransformationBase) {
-            return new value.constructor(value.toOptions());
-          }
-        });
-        // Handling of "if" statements precedes other options as it creates a chained transformation
-        if (options["if"]) {
-          this.set("if", options["if"]);
-          delete options["if"];
-        }
-        for (let key in options) {
-          let opt = options[key];
+      });
+      // Handling of "if" statements precedes other options as it creates a chained transformation
+      if (options["if"]) {
+        this.set("if", options["if"]);
+        delete options["if"];
+      }
+      for (let key in options) {
+        let opt = options[key];
+        if(opt != null) {
           if (key.match(VAR_NAME_RE)) {
             if (key !== '$attr') {
               this.set('variable', key, opt);
@@ -465,6 +465,10 @@ class TransformationBase {
 
   toString() {
     return this.serialize();
+  }
+
+  clone() {
+    return new this.constructor(this.toOptions(true));
   }
 
 };

--- a/test/docRoot/spec-runner-sources.html
+++ b/test/docRoot/spec-runner-sources.html
@@ -20,6 +20,7 @@
     <script type="text/javascript" src="../../src/util/lodash.js"></script>
     <script type="text/javascript" src="../../src/layer/layer.js"></script>
     <script type="text/javascript" src="../../src/layer/textlayer.js"></script>
+    <script type="text/javascript" src="../../src/layer/fetchlayer.js"></script>
     <script type="text/javascript" src="../../src/layer/subtitleslayer.js"></script>
     <script type="text/javascript" src="../../src/parameters.js"></script>
     <script type="text/javascript" src="../../src/configuration.js"></script>

--- a/test/spec/chaining-spec.js
+++ b/test/spec/chaining-spec.js
@@ -21,10 +21,8 @@ describe("Chaining", function() {
   DEFAULT_UPLOAD_PATH = `${protocol}//res.cloudinary.com/test123/image/upload/`;
   config = {
     cloud_name: "test123",
-    secure_distribution: null,
     private_cdn: false,
     secure: false,
-    cname: null,
     cdn_subdomain: false,
     api_key: "1234",
     api_secret: "b"

--- a/test/spec/layer-spec.js
+++ b/test/spec/layer-spec.js
@@ -1,10 +1,18 @@
-var FetchLayer, TextLayer;
-
-TextLayer = cloudinary.TextLayer;
-
-FetchLayer = cloudinary.FetchLayer;
+const {TextLayer, FetchLayer} = cloudinary;
 
 describe("TextLayer", function() {
+  it("should clone", function() {
+    const options = {
+      text: "Cloudinary for the win!",
+      fontFamily: "Arial",
+      fontSize: 18
+    };
+    const first = new TextLayer(options);
+    const second = first.clone();
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+    expect(first.toString()).toEqual(second.toString());
+  });
   it("should serialize a text layer object", function() {
     var layer, options, transformation;
     options = {

--- a/test/spec/tagspec.js
+++ b/test/spec/tagspec.js
@@ -159,10 +159,8 @@ describe("Cloudinary.VideoTag", function() {
   DEFAULT_UPLOAD_PATH = `${protocol}//res.cloudinary.com/test123/image/upload/`;
   config = {
     cloud_name: "test123",
-    secure_distribution: null,
     private_cdn: false,
     secure: false,
-    cname: null,
     cdn_subdomain: false,
     api_key: "1234",
     api_secret: "b"

--- a/test/spec/transformation-spec.js
+++ b/test/spec/transformation-spec.js
@@ -29,6 +29,14 @@ describe("Transformation", function() {
       return document.body.appendChild(fixtureContainer);
     }
   });
+  it('should clone', function() {
+    const first = cloudinary.Transformation["new"]({
+      width: 100,
+      crop: 'scale'
+    }).chain().angle(10);
+    const second = first.clone();
+    return expect(first.toString()).toEqual(second.toString());
+  });
   it('should support custom function remote', function() {
     return expect(cl.url('test', {
       transformation: [
@@ -866,13 +874,22 @@ describe("Transformation", function() {
       expect(transformation.toHtmlAttributes().height).toBeUndefined();
       return expect(transformation.toHtmlAttributes().width).toBeUndefined();
     });
-    it("should support fetch:URL", function() {
+    it("should support fetch:URL literal", function() {
       var result, transformation;
       transformation = new Transformation().overlay("fetch:http://cloudinary.com/images/old_logo.png");
       result = transformation.serialize();
       expect(result).toEqual("l_fetch:aHR0cDovL2Nsb3VkaW5hcnkuY29tL2ltYWdlcy9vbGRfbG9nby5wbmc=");
-      transformation = new Transformation().overlay("fetch:https://upload.wikimedia.org/wikipedia/commons/2/2b/고창갯벌.jpg");
-      result = transformation.serialize();
+    });
+    it("should support fetch:URL FetchLayer", function() {
+      const transformation = new Transformation({
+        overlay: new FetchLayer("http://cloudinary.com/images/old_logo.png")
+      });
+      const result = transformation.serialize();
+      return expect(result).toEqual("l_fetch:aHR0cDovL2Nsb3VkaW5hcnkuY29tL2ltYWdlcy9vbGRfbG9nby5wbmc=");
+    });
+    it("should support fetch:URL Unicode", function() {
+      const transformation = new Transformation().overlay("fetch:https://upload.wikimedia.org/wikipedia/commons/2/2b/고창갯벌.jpg");
+      const result = transformation.serialize();
       return expect(result).toEqual("l_fetch:aHR0cHM6Ly91cGxvYWQud2lraW1lZGlhLm9yZy93aWtpcGVkaWEvY29tbW9ucy8yLzJiLyVFQSVCMyVBMCVFQyVCMCVCRCVFQSVCMCVBRiVFQiVCMiU4Qy5qcGc=");
     });
     describe("chained functions", function() {

--- a/test/spec/videourlspec.js
+++ b/test/spec/videourlspec.js
@@ -16,10 +16,8 @@ describe("Cloudinary::Utils", function() {
   beforeEach(function() {
     return cl = new cloudinary.Cloudinary({
       cloud_name: "test123",
-      secure_distribution: null,
       private_cdn: false,
       secure: false,
-      cname: null,
       cdn_subdomain: false,
       api_key: "1234",
       api_secret: "b"


### PR DESCRIPTION
Reimplemented #141 in ES6

- Fix fetch layer test (RegExp::Test implicitly converts it's argument to string. The next line will result in error if the argument is not a string)
- Fix Layer cloning (Support creating a transformation with a plain object that has a `Layer` value)
- Refactor LayerParam value