### PR TITLE
Support the option to exclude versions when generating delivery urls

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -158,12 +158,9 @@ export default function url(publicId, options = {}, config = {}) {
   if (!options.cloud_name) {
     throw 'Unknown cloud_name';
   }
-  // if publicId has a '/' and doesn't begin with v<number> and doesn't start with http[s]:/ and version is empty
-  if (publicId.search('/') >= 0 && !publicId.match(/^v[0-9]+/) && !publicId.match(/^https?:\//) && !((ref = options.version) != null ? ref.toString() : void 0)) {
-    //default of options.force_version is true
-    if (options.force_version !== false) {
+  // if publicId has a '/' and doesn't begin with v<number> and doesn't start with http[s]:/ and version is empty and force_version is truthy or undefined
+  if (publicId.search('/') >= 0 && !publicId.match(/^v[0-9]+/) && !publicId.match(/^https?:\//) && !((ref = options.version) != null ? ref.toString() : void 0) && (options.force_version || typeof options.force_version === 'undefined')) {
       options.version = 1;
-    }
   }
   if (publicId.match(/^https?:/)) {
     if (options.type === 'upload' || options.type === 'asset') {

--- a/src/url.js
+++ b/src/url.js
@@ -159,7 +159,7 @@ export default function url(publicId, options = {}, config = {}) {
     throw 'Unknown cloud_name';
   }
   // if publicId has a '/' and doesn't begin with v<number> and doesn't start with http[s]:/ and version is empty and force_version is truthy or undefined
-  if (publicId.search('/') >= 0 && !publicId.match(/^v[0-9]+/) && !publicId.match(/^https?:\//) && !((ref = options.version) != null ? ref.toString() : void 0) && (options.force_version || typeof options.force_version === 'undefined')) {
+  if ((options.force_version || typeof options.force_version === 'undefined') && publicId.search('/') >= 0 && !publicId.match(/^v[0-9]+/) && !publicId.match(/^https?:\//) && !((ref = options.version) != null ? ref.toString() : void 0)) {
       options.version = 1;
   }
   if (publicId.match(/^https?:/)) {

--- a/src/url.js
+++ b/src/url.js
@@ -160,7 +160,10 @@ export default function url(publicId, options = {}, config = {}) {
   }
   // if publicId has a '/' and doesn't begin with v<number> and doesn't start with http[s]:/ and version is empty
   if (publicId.search('/') >= 0 && !publicId.match(/^v[0-9]+/) && !publicId.match(/^https?:\//) && !((ref = options.version) != null ? ref.toString() : void 0)) {
-    options.version = 1;
+    //default of options.force_version is true
+    if (options.force_version !== false) {
+      options.version = 1;
+    }
   }
   if (publicId.match(/^https?:/)) {
     if (options.type === 'upload' || options.type === 'asset') {

--- a/test/spec/cloudinary-spec.js
+++ b/test/spec/cloudinary-spec.js
@@ -158,6 +158,14 @@ describe('Cloudinary', function() {
   });
   it('should add version if public_id contains /', function() {
     test_cloudinary_url('folder/test', {}, protocol + '//res.cloudinary.com/test123/image/upload/v1/folder/test', {});
+    test_cloudinary_url('folder/test', {
+      version: 123,
+      force_version:false
+    }, protocol + '//res.cloudinary.com/test123/image/upload/v123/folder/test', {force_version:false});
+    test_cloudinary_url('folder/test', {
+      version: 123,
+      force_version:true
+    }, protocol + '//res.cloudinary.com/test123/image/upload/v123/folder/test', {force_version:true});
     return test_cloudinary_url('folder/test', {
       version: 123
     }, protocol + '//res.cloudinary.com/test123/image/upload/v123/folder/test', {});
@@ -169,6 +177,10 @@ describe('Cloudinary', function() {
     return test_cloudinary_url('test', {
       shorten: true
     }, protocol + '//res.cloudinary.com/test123/iu/test', {});
+  });
+  it('Should not set default version if force_version is set to false', function() {
+    test_cloudinary_url('folder/test', {force_version:false}, protocol + '//res.cloudinary.com/test123/image/upload/folder/test', {force_version:false});
+    return test_cloudinary_url('sample.jpg', {force_version:false}, protocol + '//res.cloudinary.com/test123/image/upload/sample.jpg', {force_version:false});
   });
   it("should support url_suffix in shared distribution", function() {
     test_cloudinary_url("test", {


### PR DESCRIPTION
User can set force_version=false (default is true)