### PR TITLE
Fix: Typescript Type Definition for Configuration.Options.secure_distribution type

### DIFF
--- a/types/cloudinary-core.d.ts
+++ b/types/cloudinary-core.d.ts
@@ -849,7 +849,7 @@ export namespace Configuration {
         responsive?: boolean;
         responsive_width?: string;
         secure_cdn_subdomain?: boolean;
-        secure_distribution?: boolean;
+        secure_distribution?: string;
         shorten?: string;
         type?: string;
         url_suffix?: string;


### PR DESCRIPTION
The Type definition for Configuration.Options.secure_distribution is wrong. Type definitions declare it as boolean | undefined

https://github.com/cloudinary/cloudinary_js/blob/eeb218694ee69e643eb3bbe455815b5da82e5a5f/types/cloudinary-core.d.ts#L852

Whereas Usage inline-docs and application behavior indicate it must be a string containing the cname to use, not just a boolean value.

https://github.com/cloudinary/cloudinary_js/blob/f5e50d3bec52e0b320e7caa76cba440e0e4bba53/src/url.js#L56

https://github.com/cloudinary/cloudinary_js/blob/f5e50d3bec52e0b320e7caa76cba440e0e4bba53/src/url.js#L90