### PR TITLE
Fix lodash isElement, isFunction and trim imports

### DIFF
--- a/src/util/lodash.js
+++ b/src/util/lodash.js
@@ -48,9 +48,9 @@ export {
   default as contains
 } from 'lodash/includes';
 
-import * as isElement from 'lodash/isElement';
-import * as isFunction from 'lodash/isFunction';
-import * as trim from 'lodash/trim';
+import isElement from 'lodash/isElement';
+import isFunction from 'lodash/isFunction';
+import trim from 'lodash/trim';
 
 export * from './baseutil';
 export {


### PR DESCRIPTION
There is no need to import all the exported symbols when lodash has the default export.

https://github.com/lodash/lodash/blob/master/trim.js#L38
https://github.com/lodash/lodash/blob/master/isElement.js#L23
https://github.com/lodash/lodash/blob/master/isFunction.js#L30