### PR TITLE
Add bundlewatch Service

### DIFF
--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -17,7 +17,7 @@ const bundlewatchConfig = {
       maxSize: '47kb'
     }
   ],
-  defaultCompression: 'gzip',  // Do we want the results in gzip form?
+  defaultCompression: 'gzip',
 };
 
 module.exports = bundlewatchConfig;

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -6,15 +6,15 @@ const bundlewatchConfig = {
     },
     {
       path: './dist/cloudinary-core-shrinkwrap.min.js',
-      maxSize: '27kb'
+      maxSize: '30kb'
     },
     {
-      path: './dist/cloudinary-jquery.js',
-      maxSize: '45kb'
+      path: './dist/cloudinary-jquery.min.js',
+      maxSize: '20kb'
     },
     {
-      path: './dist/cloudinary-jquery-file-upload.js',
-      maxSize: '47kb'
+      path: './dist/cloudinary-jquery-file-upload.min.js',
+      maxSize: '20kb'
     }
   ],
   defaultCompression: 'gzip',

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -1,0 +1,23 @@
+const bundlewatchConfig = {
+  files: [
+    {
+      path: './dist/cloudinary-core.min.js',
+      maxSize: '20kb'
+    },
+    {
+      path: './dist/cloudinary-core-shrinkwrap.min.js',
+      maxSize: '27kb'
+    },
+    {
+      path: './dist/cloudinary-jquery.js',
+      maxSize: '45kb'
+    },
+    {
+      path: './dist/cloudinary-jquery-file-upload.js',
+      maxSize: '47kb'
+    }
+  ],
+  defaultCompression: 'gzip',  // Do we want the results in gzip form?
+};
+
+module.exports = bundlewatchConfig;

--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -14,7 +14,7 @@ const bundlewatchConfig = {
     },
     {
       path: './dist/cloudinary-jquery-file-upload.min.js',
-      maxSize: '20kb'
+      maxSize: '21kb'
     }
   ],
   defaultCompression: 'gzip',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "src/**/*"
   ],
   "scripts": {
-    "build": "parallel-webpack",
+    "build": "parallel-webpack && npm run bundlewatch",
+    "bundlewatch": "bundlewatch --config ./bundlewatch.config.js",
     "doc": "jsdoc -c jsdoc-conf.json",
     "test": "karma start --single-run --browsers=ChromeHeadless",
     "test:watch": "karma start --auto-watch --browsers=ChromeHeadless",
@@ -65,6 +66,7 @@
     "webpack-cli": "^3.3.0"
   },
   "dependencies": {
+    "bundlewatch": "^0.2.6",
     "jsdoc": "^3.6.3"
   }
 }


### PR DESCRIPTION
Integration with BundleWatch to report on Github if files exceed their expected sizes.
<img width="754" alt="Screen Shot 2020-03-23 at 15 24 56" src="https://user-images.githubusercontent.com/17492957/77321702-3d681f80-6d1b-11ea-99bf-44300aa75ab1.png">
