### PR TITLE
Fix normalize_expression when variable is named like a keyword (e.g., "$width")

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -1487,7 +1487,7 @@ var slice = [].slice,
       }
       expression = String(expression);
       operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
-      pattern = "((" + operators + ")(?=[ _])|" + Object.keys(Expression.PREDEFINED_VARS).join("|") + ")";
+      pattern = "((" + operators + ")(?=[ _])|(?<!\$)(" + Object.keys(Expression.PREDEFINED_VARS).join("|") + "))";
       replaceRE = new RegExp(pattern, "g");
       expression = expression.replace(replaceRE, function(match) {
         return Expression.OPERATORS[match] || Expression.PREDEFINED_VARS[match];

--- a/src/expression.js
+++ b/src/expression.js
@@ -37,7 +37,7 @@ class Expression {
     }
     expression = String(expression);
     operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
-    pattern = "((" + operators + ")(?=[ _])|" + Object.keys(Expression.PREDEFINED_VARS).join("|") + ")";
+    pattern = "((" + operators + ")(?=[ _])|(?<!\\$)(" + Object.keys(Expression.PREDEFINED_VARS).join("|") + "))";
     replaceRE = new RegExp(pattern, "g");
     expression = expression.replace(replaceRE, function (match) {
       return Expression.OPERATORS[match] || Expression.PREDEFINED_VARS[match];

--- a/test/spec/transformation-spec.js
+++ b/test/spec/transformation-spec.js
@@ -100,6 +100,19 @@ describe("Transformation", function() {
       transformation: {}
     })).toBe(protocol + '//res.cloudinary.com/test123/image/upload/test');
   });
+  it('should not change variable names even if they look like keywords', function() {
+    const options = { transformation: [
+        {
+          $width: 10,
+        },
+        {
+          width: '$width + 10 + width',
+          crop: 'scale',
+        },
+      ]};
+    const t = cloudinary.Transformation.new(options);
+    expect(t.toString()).toEqual('$width_10/c_scale,w_$width_add_10_add_w');
+  });
   describe("width and height", function() {
     it('should use width and height from options only if crop is given', function() {
       expect(cl.url('test', {


### PR DESCRIPTION
`normalize_expression()` will no longer transform predefined variables into their shortened form if they are preceded by an ampersand (meaning they are variables).

For example: `$width` will not be transformed into `$w`.

💡 Note our [comments in the PR](https://github.com/cloudinary/cloudinary_npm/pull/367#issue-402081963) for `cloudinary_npm` which would also apply here. The solution proposed here will not work on old browsers that do not support lookbehind in regular expressions.