### PR TITLE
Fix/update readme coffeescript grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cloudinary provides URL and HTTP based APIs that can be easily integrated with a
 
 ## New API!
 
-The version 2.0.0 release refactors the Cloudinary JavaScript library, and the biggest news is that the newly introduced Core Library is jQuery-independent. The source code has been converted into CoffeeScript and rearranged into classes, and a new build script based on Grunt has been added. The build process produces 3 artifacts:
+The version 2.0.0 release refactors the Cloudinary JavaScript library, and the biggest news is that the newly introduced Core Library is jQuery-independent. The build process produces 3 artifacts:
 
 Github Repository                                                                                    | Package name                    | Description
 -----------------------------------------------------------------------------------------------------|---------------------------------|--------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Cloudinary provides URL and HTTP based APIs that can be easily integrated with a
 
 ## New API!
 
-Version 2.x.x refactored the Cloudinary JavaScript library, and the biggest news is that the newly introduced Core Library is jQuery-independent. The build process produces 3 artifacts:
+Version 2.x.x is a completely refactored Cloudinary JavaScript library, and the biggest news is that the newly introduced Core Library is jQuery-independent.
+
+The build process produces 3 artifacts:
 
 Github Repository                                                                                    | Package name                    | Description
 -----------------------------------------------------------------------------------------------------|---------------------------------|--------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cloudinary provides URL and HTTP based APIs that can be easily integrated with a
 
 ## New API!
 
-The version 2.0.0 release refactors the Cloudinary JavaScript library, and the biggest news is that the newly introduced Core Library is jQuery-independent. The build process produces 3 artifacts:
+Version 2.x.x refactored the Cloudinary JavaScript library, and the biggest news is that the newly introduced Core Library is jQuery-independent. The build process produces 3 artifacts:
 
 Github Repository                                                                                    | Package name                    | Description
 -----------------------------------------------------------------------------------------------------|---------------------------------|--------------------------------------------------------------------------


### PR DESCRIPTION
While factually true (for 2.0.0) this statement in the README can confuse the reader into thinking `cloudinary_js` uses CoffeeScript and Grunt. The updated paragraph is more inline with what would be expected from a README as opposed to a changelog.