### PR TITLE
Added POW operator support

### DIFF
--- a/js/jquery.cloudinary.js
+++ b/js/jquery.cloudinary.js
@@ -1403,7 +1403,8 @@ var slice = [].slice,
       "*": "mul",
       "/": "div",
       "+": "add",
-      "-": "sub"
+      "-": "sub",
+      "^": "pow",
     };
 
 
@@ -1486,7 +1487,7 @@ var slice = [].slice,
         return expression;
       }
       expression = String(expression);
-      operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
+      operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*|\\^";
       pattern = "((" + operators + ")(?=[ _])|(?<!\$)(" + Object.keys(Expression.PREDEFINED_VARS).join("|") + "))";
       replaceRE = new RegExp(pattern, "g");
       expression = expression.replace(replaceRE, function(match) {

--- a/src/expression.js
+++ b/src/expression.js
@@ -36,7 +36,7 @@ class Expression {
       return expression;
     }
     expression = String(expression);
-    operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*";
+    operators = "\\|\\||>=|<=|&&|!=|>|=|<|/|-|\\+|\\*|\\^";
     pattern = "((" + operators + ")(?=[ _])|(?<!\\$)(" + Object.keys(Expression.PREDEFINED_VARS).join("|") + "))";
     replaceRE = new RegExp(pattern, "g");
     expression = expression.replace(replaceRE, function (match) {
@@ -287,7 +287,8 @@ Expression.OPERATORS = {
   "*": "mul",
   "/": "div",
   "+": "add",
-  "-": "sub"
+  "-": "sub",
+  "^": "pow",
 };
 
 /**

--- a/test/spec/transformation-spec.js
+++ b/test/spec/transformation-spec.js
@@ -874,6 +874,12 @@ describe("Transformation", function() {
       t = new Transformation(options).toString();
       return expect(t).toEqual("$foo_10/if_fc_gt_2/c_scale,w_$foo_mul_200_div_fc/if_end");
     });
+    it("should support and translate pow operator", function () {
+      test_cloudinary_url("sample", {
+        $small: 150,
+        $big: "$small ^ 1.5",
+      }, `http://res.cloudinary.com/test123/image/upload/$big_$small_pow_1.5,$small_150/sample`, {});
+    });
     it("should sort variables", function() {
       var t;
       t = new Transformation({


### PR DESCRIPTION
Added support for the power operator.

For example:

```javascript
new cloudinary.Transformation({
  $small: 150,
  $big: "$small ^ 1.5",
})
```

Should yield a transformation string like: `$big_$small_pow_1.5,$small_150`