### PR TITLE
Fix/types docs

### DIFF
--- a/types/cloudinary-core.d.ts
+++ b/types/cloudinary-core.d.ts
@@ -630,7 +630,11 @@ export class Param {
  * @param {Object} options - options to configure Cloudinary
  * @see Configuration for more details
  * @example
+ *    // Include cloudinary_js in a <script> tag, then:
  *    var cl = new cloudinary.Cloudinary( { cloud_name: "mycloud"});
+ *    // Or import it from the npm package:
+ *    import { Cloudinary } from 'cloudinary-core';
+ *    var cl = new Cloudinary( { cloud_name: "mycloud"});
  *    var imgTag = cl.image("myPicID");
  */
 export class Cloudinary {

--- a/types/cloudinary-core.d.ts
+++ b/types/cloudinary-core.d.ts
@@ -550,7 +550,7 @@ export class TextLayer extends Layer {
     fontWeight(value: string): TextLayer;
     fontStyle(value: string): TextLayer;
     fontHinting(value: string): TextLayer;
-    fontAntiAliasing(value: string): TextLayer;
+    fontAntialiasing(value: string): TextLayer;
     textDecoration(value: string): TextLayer;
     textAlign(value: string): TextLayer;
     stroke(value: string): TextLayer;


### PR DESCRIPTION
This pr updates type definitions:
1. I noticed that font antialiasing was misspelled, so fixed it.
2. Users have typescript warnings when following the example for using the Cloudinary class, see: https://github.com/cloudinary/cloudinary_js/issues/192
So updated the example.
