### PR TITLE
Feature/add strict null check for types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,13 @@
         "noImplicitAny": true,
         "esModuleInterop": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "strictPropertyInitialization": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noImplicitReturns" : true,
+        "noUnusedLocals" : true,
+        "noUnusedParameters": true,
         "allowSyntheticDefaultImports": true,
         "typeRoots": ["./types"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "noImplicitAny": true,
         "esModuleInterop": true,
+        "strictNullChecks": true,
         "allowSyntheticDefaultImports": true,
         "typeRoots": ["./types"]
     }

--- a/types/cloudinary-core-tests.ts
+++ b/types/cloudinary-core-tests.ts
@@ -4,11 +4,10 @@
 
 
 import {
-    Cloudinary, Util, Configuration, Transformation, ImageTag, PictureTag, VideoTag, Condition, Layer, TextLayer, HtmlTag,
+    Cloudinary, Util, Configuration, Transformation, ImageTag, VideoTag, Layer, TextLayer, HtmlTag,
     ClientHintsMetaTag, Param
 } from './cloudinary-core';
 
-import cloudinary from './cloudinary-core';
 
 let config: Configuration.Options = { cloud_name: 'demo' };
 
@@ -26,11 +25,9 @@ cld.injectTransparentVideoElement(document.createElement('div'), 'woman', {
     seeThruURL: 'https://...'
 }).then((resp) => {
     if (resp instanceof HTMLElement) {
-        let container = resp; // the container we provided
     }
 }).catch((resp) => {
     if (typeof resp.status === 'string') {
-        let {status, message} = resp;
     }
 });
 
@@ -73,14 +70,14 @@ cld.url('sample', {
     ]
 }) // http://res.cloudinary.com/demo/image/upload/if_w_lt_200,c_fill,h_120,w_80/if_w_gt_400,c_fit,h_150,w_150/e_sepia/sample
 
-const publicId = 'imagePublicId';
-let image: HTMLImageElement = cld.image(publicId); // image.src == http://res.cloudinary.com/demo/image/upload/${publicId}
+// const publicId = 'imagePublicId';
+// let image: HTMLImageElement = cld.image(publicId); // image.src == http://res.cloudinary.com/demo/image/upload/${publicId}
 
 
-let video: string = cld.video(publicId); // video == <video poster="http://res.cloudinary.com/demo/video/upload/${publicId}.jpg"><source src="http://res.cloudinary.com/demo/video/upload/${publicId}.webm" type="video/webm"><source src="http://res.cloudinary.com/demo/video/upload/${publicId}.mp4" type="video/mp4"><source src="http://res.cloudinary.com/demo/video/upload/${publicId}.ogv" type="video/ogg"></video>
+// let video: string = cld.video(publicId); // video == <video poster="http://res.cloudinary.com/demo/video/upload/${publicId}.jpg"><source src="http://res.cloudinary.com/demo/video/upload/${publicId}.webm" type="video/webm"><source src="http://res.cloudinary.com/demo/video/upload/${publicId}.mp4" type="video/mp4"><source src="http://res.cloudinary.com/demo/video/upload/${publicId}.ogv" type="video/ogg"></video>
 
 
-const videoTag: VideoTag = cld.videoTag(publicId); // videoTag.getOption('source_types')) == ['webm', 'mp4', 'ogv']
+// const videoTag: VideoTag = cld.videoTag(publicId); // videoTag.getOption('source_types')) == ['webm', 'mp4', 'ogv']
 
 
 cld.transformation_string({
@@ -118,12 +115,12 @@ transformation.serialize();
 transformation.toHtmlAttributes();
 
 
-let url: string = cld.url('sample', cld.transformation().if().width('gt', 100).and().width('lt', 200).then().width(50).crop('scale').endIf()); // http://res.cloudinary.com/demo/image/upload/if_w_gt_100_and_w_lt_200/c_scale,w_50/if_end/sample
+// let url: string = cld.url('sample', cld.transformation().if().width('gt', 100).and().width('lt', 200).then().width(50).crop('scale').endIf()); // http://res.cloudinary.com/demo/image/upload/if_w_gt_100_and_w_lt_200/c_scale,w_50/if_end/sample
 
 
-url = cld.url('sample', cld.transformation().if().width("gt", 100).and().width("lt", 200).then().width(50).crop("scale").endIf()); // http://res.cloudinary.com/demo/image/upload/if_w_gt_100_and_w_lt_200/c_scale,w_50/if_end/sample
+cld.url('sample', cld.transformation().if().width("gt", 100).and().width("lt", 200).then().width(50).crop("scale").endIf()); // http://res.cloudinary.com/demo/image/upload/if_w_gt_100_and_w_lt_200/c_scale,w_50/if_end/sample
 
-url = cld.url('sample', cld.transformation().if().width("gt", 100).and().width("lt", 200).then().width(50).crop("scale").else().width(100).crop("crop").endIf()); // http://res.cloudinary.com/demo/image/upload/if_w_gt_100_and_w_lt_200/c_scale,w_50/if_else/c_crop,w_100/if_end/sample
+cld.url('sample', cld.transformation().if().width("gt", 100).and().width("lt", 200).then().width(50).crop("scale").else().width(100).crop("crop").endIf()); // http://res.cloudinary.com/demo/image/upload/if_w_gt_100_and_w_lt_200/c_scale,w_50/if_else/c_crop,w_100/if_end/sample
 
 
 transformation = cld.transformation().if("w > 1000 and aspectRatio < 3:4")
@@ -132,10 +129,10 @@ transformation = cld.transformation().if("w > 1000 and aspectRatio < 3:4")
     .else()
     .width(500)
     .crop("scale");
-url = cld.url('sample', transformation); // http://res.cloudinary.com/demo/image/upload/if_w_gt_1000_and_ar_lt_3:4,c_scale,w_1000/if_else,c_scale,w_500/sample
+cld.url('sample', transformation); // http://res.cloudinary.com/demo/image/upload/if_w_gt_1000_and_ar_lt_3:4,c_scale,w_1000/if_else,c_scale,w_500/sample
 
 
-image = cld.facebook_profile_image('officialchucknorrispage',
+cld.facebook_profile_image('officialchucknorrispage',
     {
         secure: true,
         responsive: true,
@@ -143,10 +140,10 @@ image = cld.facebook_profile_image('officialchucknorrispage',
     }); // image.src == https://res.cloudinary.com/demo/image/facebook/e_art:hokusai/officialchucknorrispage && image.getAttribute('data-src-cache') == expectedImageUrl
 
 
-let tag = ImageTag.new("publicId");
+ImageTag.new("publicId");
 
 
-let videoHtml = cld.videoTag("movie").setSourceTypes('mp4')
+cld.videoTag("movie").setSourceTypes('mp4')
     .transformation()
     .htmlHeight("100")
     .htmlWidth("200")

--- a/types/cloudinary-core.d.ts
+++ b/types/cloudinary-core.d.ts
@@ -850,8 +850,9 @@ export class Cloudinary {
 
 interface TransparentVideoOptions extends Transformation.Options {
     externalLibraries?: {
-        seeThru?: string,
         [future:string]:string
+    } & {
+        seeThru?: string,
     }
     loop?: boolean,
     autoplay?: true,
@@ -896,14 +897,14 @@ export namespace Configuration {
         api_secret?: string;
         cdn_subdomain?: boolean;
         cloud_name?: string;
-        cname?: string;
+        cname?: string | null;
         private_cdn?: boolean;
         protocol?: string;
         resource_type?: string;
         responsive?: boolean;
         responsive_width?: string;
         secure_cdn_subdomain?: boolean;
-        secure_distribution?: string;
+        secure_distribution?: string | null;
         shorten?: string;
         type?: string;
         url_suffix?: string;

--- a/types/cloudinary-core.d.ts
+++ b/types/cloudinary-core.d.ts
@@ -82,7 +82,7 @@ export class Util {
     static detectIntersection(element: Element, onIntersect: Function): void
 
     static getAnalyticsOptions(options: AnalyticsOptionsParameters) : AnalyticsOptions;
-    static getSDKAnalyticsSignature(options: AnalyticsOptions):string;;
+    static getSDKAnalyticsSignature(options: AnalyticsOptions):string;
 }
 
 
@@ -314,7 +314,7 @@ export class Condition {
 export namespace Transformation {
     export interface Options extends Configuration.Options {
         angle?: Angle; // degrees or mode
-        aspectRatio?: string | number | string; // ratio or percent, e.g. 1.5 or 16:9
+        aspectRatio?: string | number; // ratio or percent, e.g. 1.5 or 16:9
         background?: string; // color, e.g. "blue" or "rgb:9090ff"
         border?: string; // style, e.g. "6px_solid_rgb:00390b60"
         color?: string; // e.g. "red" or "rgb:20a020"
@@ -338,7 +338,7 @@ export namespace Transformation {
         "else"?: string;
         endIf?: string;
         opacity?: number | string; // percent, 0-100
-        overlay?: string | string; // Identifier, e.g. "text:Arial_50:Smile!", or public id of a different resource
+        overlay?: string; // Identifier, e.g. "text:Arial_50:Smile!", or public id of a different resource
         page?: number | string; // Given a multi-page file (PDF, animated GIF, TIFF), generate an image of a single page using the given index.
         prefix?: string;
         quality?: string | number; // percent or percent[:chroma_subsampling] or auto[:quality_level]


### PR DESCRIPTION
This PR fixes  https://github.com/cloudinary/cloudinary-react/issues/188 in React (and a similar one in Angular).

When projects that use this package use strict null checks (in typescript), some of the definitions are malformed and throw exceptions.

This PR adds the strict null check to this project and fixes the declerations