### PR TITLE
Fix native lazyloading detection

### DIFF
--- a/src/util/lazyLoad.js
+++ b/src/util/lazyLoad.js
@@ -16,7 +16,8 @@ export function isIntersectionObserverSupported() {
  * @return {boolean} true if 'loading' property is defined for HTMLImageElement
  */
 export function isNativeLazyLoadSupported() {
-  return typeof HTMLImageElement === "object" && HTMLImageElement.prototype.loading;
+  return 'loading' in HTMLImageElement.prototype &&
+    'loading' in HTMLIFrameElement.prototype;
 }
 
 /**


### PR DESCRIPTION
Currently the [Native Lazyloading](https://caniuse.com/#feat=loading-lazy-attr) detection is broken (at least on 84.0.4147.125).

When running previous implementation of
```
typeof HTMLImageElement === "object" && HTMLImageElement.prototype.loading;
```
It results in `false`. This is at least in part due to `typeof HTMLImageElement` resulting in `"function"`.

I have copied the implementation from the polyfill for loading attribute, here: https://github.com/mfranzke/loading-attribute-polyfill/blob/master/loading-attribute-polyfill.js