### PR TITLE
Fix safari transparent video support

### DIFF
--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -1,0 +1,42 @@
+/**
+ * Based on video.js implementation:
+ * https://github.com/videojs/video.js/blob/4238f5c1d88890547153e7e1de7bd0d1d8e0b236/src/js/utils/browser.js
+ */
+
+// User agent example taken from Safari desktop:
+const useAgent = navigator && navigator.userAgent || '';
+
+/**
+ * Detect if current browser is any Android
+ * @returns true if current browser is Android, false otherwise.
+ */
+export function isAndroid(){
+  return (/Android/i).test(useAgent);
+}
+
+/**
+ * Detect if current browser is any Edge
+ * @returns true if current browser is Edge, false otherwise.
+ */
+export function isEdge(){
+  return (/Edg/i).test(useAgent);
+}
+
+/**
+ * Detect if current browser is chrome.
+ * @returns true if current browser is Chrome, false otherwise.
+ */
+export function isChrome(){
+  return !isEdge() && ((/Chrome/i).test(useAgent) || (/CriOS/i).test(useAgent));
+}
+
+/**
+ * Detect if current browser is Safari.
+ * @returns true if current browser is Safari, false otherwise.
+ */
+export function isSafari(){
+  // User agents for other browsers might include "Safari" so we must exclude them.
+  // For example - this is the chrome user agent on windows 10:
+  // Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36
+  return (/Safari/i).test(useAgent) && !isChrome() && !isAndroid() && !isEdge();
+}

--- a/src/util/features/transparentVideo/checkSupportForTransparency.js
+++ b/src/util/features/transparentVideo/checkSupportForTransparency.js
@@ -1,10 +1,19 @@
 /**
  * @return {Promise<boolean>} - Whether the browser supports transparent videos or not
  */
+import {isSafari} from "./util";
+
 function checkSupportForTransparency() {
   return new Promise((resolve, reject) => {
-    let video = document.createElement('video');
-    let canPlay = video.canPlayType && video.canPlayType('video/webm; codecs="vp9"');
+    // Resolve early for safari.
+    // Currently (29 December 2021) Safari can play webm/vp9,
+    // but it does not support transparent video in the format we're outputting
+    if (isSafari()){
+      resolve(false);
+    }
+
+    const video = document.createElement('video');
+    const canPlay = video.canPlayType && video.canPlayType('video/webm; codecs="vp9"');
     resolve(canPlay === 'maybe' || canPlay === 'probably');
   });
 }

--- a/src/util/jquery.js
+++ b/src/util/jquery.js
@@ -3,6 +3,7 @@
  */
 export * from './baseutil';
 export * from './lazyLoad';
+export * from './browser';
 import getSDKAnalyticsSignature from "../sdkAnalytics/getSDKAnalyticsSignature";
 import getAnalyticsOptions from "../sdkAnalytics/getAnalyticsOptions";
 export {getSDKAnalyticsSignature , getAnalyticsOptions};

--- a/src/util/lodash.js
+++ b/src/util/lodash.js
@@ -58,10 +58,13 @@ import trim from 'lodash/trim';
 
 export * from './lazyLoad';
 export * from './baseutil';
+export * from './browser';
 export {
   isElement,
   isFunction,
-  trim};
+  trim
+};
+
 /*
  * Includes utility methods and lodash / jQuery shims
  */


### PR DESCRIPTION
This pr adds a check for safari browser when choosing transparent video implementation.